### PR TITLE
react-hook-form version freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## Release Candidate
 
+### Bugfix
+
+- Temporary downgrade of `react-hook-form` from `“^7.22.1"` to `"7.37.0"` to avoid issues with non functional submit button in forms with v `"7.38.0"`. (INDIGO Sprint 221014, [!13](https://github.com/TeskaLabs/seacat-auth-webui/pull/13/files))
+
 ## v22.42
 
 ### Features
 
 - ASAB WebUI submodule version bump [[899679e](https://github.com/TeskaLabs/asab-webui/commit/https://github.com/TeskaLabs/asab-webui/commit/899679ebfab1862706504e60ceb396d72d2a4ad9)] commit (INDIGO Sprint 221014, [!10](https://github.com/TeskaLabs/seacat-auth-webui/pull/10))
 
-## Refactoring
+### Refactoring
 
 - Add correct gray background and spinner when the page is loaded (INDIGO Sprint 220916, [!4](https://github.com/TeskaLabs/seacat-auth-webui/pull/4))
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"react-content-loader": "^6.2.0",
 		"react-dom": "^17.0.0",
 		"react-helmet": "^6.1.0",
-		"react-hook-form": "^7.22.1",
+		"react-hook-form": "7.37.0",
 		"react-i18next": "^11.7.2",
 		"react-json-view": "^1.21.1",
 		"react-qr-code": "^1.0.2",


### PR DESCRIPTION
### in this MR

- version of `react-hook-form` is temorarily 'frozen' to `"7.37.0"` in order to prevent errors  of v `"7.38.0"` in Safari