### PR TITLE
Seacat Auth API refactoring 

### DIFF
--- a/src/modules/auth/containers/LoginCard.js
+++ b/src/modules/auth/containers/LoginCard.js
@@ -142,7 +142,7 @@ function LoginCard(props) {
 		let SeaCatAuthPrologueAPI = props.app.axiosCreate('seacat-auth');
 		let response;
 		try {
-			response = await SeaCatAuthPrologueAPI.put('/public/login.prologue', jwk)
+			response = await SeaCatAuthPrologueAPI.put('/public/login-prologue', jwk)
 		} catch (e) {
 			props.app.addAlert(
 				"danger",

--- a/src/modules/auth/email/EmailScreen.js
+++ b/src/modules/auth/email/EmailScreen.js
@@ -43,7 +43,7 @@ function ManageEmailCard(props) {
 	let redirect_uri = params.get("redirect_uri");
 
 	let history = useHistory();
-	let SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
+	let SeaCatAccountAPI = props.app.axiosCreate('seacat-auth/account');
 	let email = props.userinfo?.email;
 	let number = props.userinfo?.phone ? props.userinfo.phone : "";
 
@@ -66,7 +66,7 @@ function ManageEmailCard(props) {
 	const onSubmit = async (values) => {
 		let response;
 		try {
-			response = await SeaCatAuthAPI.put("/public/credentials",
+			response = await SeaCatAccountAPI.put("/credentials",
 				JSON.stringify(values),
 				{ headers: {
 					'Content-Type': 'application/json'

--- a/src/modules/auth/home/HomeScreen.js
+++ b/src/modules/auth/home/HomeScreen.js
@@ -28,6 +28,7 @@ function HomeScreen(props) {
 	const { t } = useTranslation();
 	const history = useHistory();
 	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
+	const SeaCatAccountAPI = props.app.axiosCreate('seacat-auth/account');
 
 	generatePenrose();
 	
@@ -70,7 +71,7 @@ function HomeScreen(props) {
 
 	const fetchUpdateFeatures = async () => {
 		try {
-			const response = await SeaCatAuthAPI.get("/public/provider");
+			const response = await SeaCatAccountAPI.get("/provider");
 
 			if (response.data.result != "OK") throw response;
 
@@ -87,7 +88,7 @@ function HomeScreen(props) {
 
 	const fetchLastLogin = async () => {
 		try {
-			const response = await SeaCatAuthAPI.get("/public/last_login");
+			const response = await SeaCatAccountAPI.get("/last_login");
 			setLastLogin(response.data);
 		} catch (e) {
 			console.error(e);
@@ -148,7 +149,7 @@ function HomeScreen(props) {
 	const logoutAll = async () => {
 		let response;
 		try {
-			response = await SeaCatAuthAPI.delete('/public/sessions');
+			response = await SeaCatAccountAPI.delete('/public/sessions');
 			if (response.data.result !== "OK") {
 				throw new Error(t("HomeScreen|Something went wrong when logging you out from all devices"));
 			}
@@ -188,7 +189,7 @@ function HomeScreen(props) {
 	// Remove external service method
 	const removeExternalService = async (provider) => {
 		try {
-			await SeaCatAuthAPI.delete("/public/ext-login/" + provider);
+			await SeaCatAccountAPI.delete("/ext-login/" + provider);
 			props.app.addAlert("success", t("HomeScreen|Service was successfully disconnected"));
 			// reload in order to get updated userinfo
 			window.location.reload();

--- a/src/modules/auth/home/HomeScreen.js
+++ b/src/modules/auth/home/HomeScreen.js
@@ -88,7 +88,7 @@ function HomeScreen(props) {
 
 	const fetchLastLogin = async () => {
 		try {
-			const response = await SeaCatAccountAPI.get("/last_login");
+			const response = await SeaCatAccountAPI.get("/last-login");
 			setLastLogin(response.data);
 		} catch (e) {
 			console.error(e);

--- a/src/modules/auth/home/HomeScreen.js
+++ b/src/modules/auth/home/HomeScreen.js
@@ -149,7 +149,7 @@ function HomeScreen(props) {
 	const logoutAll = async () => {
 		let response;
 		try {
-			response = await SeaCatAccountAPI.delete('/public/sessions');
+			response = await SeaCatAccountAPI.delete('/sessions');
 			if (response.data.result !== "OK") {
 				throw new Error(t("HomeScreen|Something went wrong when logging you out from all devices"));
 			}

--- a/src/modules/auth/number/PhoneNumberScreen.js
+++ b/src/modules/auth/number/PhoneNumberScreen.js
@@ -44,7 +44,7 @@ function ManageNumberCard(props) {
 	let redirect_uri = params.get("redirect_uri");
 
 	let history = useHistory();
-	let SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
+	let SeaCatAccountAPI = props.app.axiosCreate('seacat-auth/account');
 	let number = props.userinfo?.phone;
 	let email = props.userinfo?.email ? props.userinfo.email : "";
 
@@ -68,7 +68,7 @@ function ManageNumberCard(props) {
 	const onSubmit = async (values) => {
 		let response;
 		try {
-			response = await SeaCatAuthAPI.put("/public/credentials",
+			response = await SeaCatAccountAPI.put("/credentials",
 				JSON.stringify(values),
 				{ headers: {
 					'Content-Type': 'application/json'

--- a/src/modules/auth/otp/TOTPScreen.js
+++ b/src/modules/auth/otp/TOTPScreen.js
@@ -36,7 +36,7 @@ function SetTOTPCard(props) {
 	const { t, i18n } = useTranslation();
 	const { handleSubmit, register, getValues, formState: { errors } } = useForm();
 	let history = useHistory();
-	let SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
+	let SeaCatAccountAPI = props.app.axiosCreate('seacat-auth/account');
 
 	let params = new URLSearchParams(useLocation().search);
 	let redirect_uri = params.get("redirect_uri");
@@ -71,7 +71,7 @@ function SetTOTPCard(props) {
 	const getData = async () => {
 		let response;
 		try {
-			response = await SeaCatAuthAPI.get("/public/totp");
+			response = await SeaCatAccountAPI.get("/totp");
 			if (response.data.result == 'OK') {
 				setActive(response.data.active);
 				setConfigURL(response.data.url);
@@ -91,7 +91,7 @@ function SetTOTPCard(props) {
 		let response;
 		if (active) {
 			try {
-				response = await SeaCatAuthAPI.put("/public/unset-totp");
+				response = await SeaCatAccountAPI.put("/unset-totp");
 				if (response.data.result !== "OK") {
 					throw new Error(t("TOTPScreen|Something went wrong, can't deactivate OTP"));
 				}
@@ -117,7 +117,7 @@ function SetTOTPCard(props) {
 
 		} else {
 			try {
-				response = await SeaCatAuthAPI.put("/public/set-totp",
+				response = await SeaCatAccountAPI.put("/set-totp",
 					JSON.stringify(values),
 					{ headers: {
 						'Content-Type': 'application/json'

--- a/src/modules/auth/passwd/ChangePwdScreen.js
+++ b/src/modules/auth/passwd/ChangePwdScreen.js
@@ -54,11 +54,11 @@ function ChangePwdCard(props) {
 	});
 
 	const onSubmit = async (values) => {
-		let SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
+		let SeaCatAccountAPI = props.app.axiosCreate('seacat-auth/account');
 		let response;
 
 		try {
-			response = await SeaCatAuthAPI.put("/public/password-change", values)
+			response = await SeaCatAccountAPI.put("/password-change", values)
 		} catch (e) {
 			props.app.addAlert("danger", `${t("ChangePwdScreen|Something went wrong")}. ${e?.response?.data?.message}`, 30);
 			return;

--- a/src/modules/auth/webauthn/WebAuthnScreen.js
+++ b/src/modules/auth/webauthn/WebAuthnScreen.js
@@ -33,7 +33,7 @@ export default function WebAuthnScreen(props) {
 function WebAuthnCard(props) {
 	const { t, i18n } = useTranslation();
 	let history = useHistory();
-	let SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
+	let SeaCatAccountAPI = props.app.axiosCreate('seacat-auth/account');
 
 	let params = new URLSearchParams(useLocation().search);
 	let redirect_uri = params.get("redirect_uri");
@@ -69,7 +69,7 @@ function WebAuthnCard(props) {
 	const getAuthenticators = async () => {
 		let response;
 		try {
-			response = await SeaCatAuthAPI.get('/public/webauthn');
+			response = await SeaCatAccountAPI.get('/webauthn');
 			// TODO: enable validation, when ready in SA service
 			if (response.data.result != 'OK') {
 				throw new Error(t("WebAuthnScreen|Something went wrong, can't retrieve authenticators"));
@@ -97,7 +97,7 @@ function WebAuthnCard(props) {
 		// Get register options for WebAuthn
 		let response;
 		try {
-			response = await SeaCatAuthAPI.get('/public/webauthn/register-options');
+			response = await SeaCatAccountAPI.get('/webauthn/register-options');
 			// TODO: enable validation, when ready in SA service
 			// if (response.data.result != 'OK') {
 			// 	throw new Error(t("WebAuthnScreen|Something went wrong, registration of authenticator failed"));
@@ -151,7 +151,7 @@ function WebAuthnCard(props) {
 		// Register credentials
 		let registerResponse;
 		try {
-			registerResponse = await SeaCatAuthAPI.put('/public/webauthn/register', credToJSON);
+			registerResponse = await SeaCatAccountAPI.put('/webauthn/register', credToJSON);
 			if (registerResponse.data.result != 'OK') {
 				throw new Error(t("WebAuthnScreen|Something went wrong, registration of authenticator failed"));
 			}
@@ -178,7 +178,7 @@ function WebAuthnCard(props) {
 	const onUnregister = async (id) => {
 		let response;
 		try {
-			response = await SeaCatAuthAPI.delete(`/public/webauthn/${id}`);
+			response = await SeaCatAccountAPI.delete(`/webauthn/${id}`);
 			// TODO: enable validation, when ready in SA service
 			if (response.data.result != 'OK') {
 				throw new Error(t("WebAuthnScreen|Something went wrong, can't unregister authenticator"));
@@ -203,7 +203,7 @@ function WebAuthnCard(props) {
 	const onSubmitKeyName = async (values) => {
 		let response;
 		try {
-			response = await SeaCatAuthAPI.put(`/public/webauthn/${values.id}`,
+			response = await SeaCatAccountAPI.put(`/webauthn/${values.id}`,
 				{"name": `${values.name}`}
 			);
 			if (response.data.result != 'OK') {


### PR DESCRIPTION
**Strict dependency on TeskaLabs/seacat-auth/pull/319. UI will not work with older Seacat Admin API versions.**

Sync merge with 
- TeskaLabs/seacat-auth/pull/319 
- http://gitlab.teskalabs.int/ateska/webui-microfrontends-poc/-/merge_requests/131

# Breaking changes
- Seacat Account management endpoints are now prefixed with `/account`
- Path `/public/login.prologue` changed to `/public/login-prologue`