### PR TITLE
Advanced password validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v24.19
+
+### Releases
+
+- v24.19-alpha
+
+### Features
+
+- Advanced password validation (#43, v24.19-alpha, PLUM Sprint 240503)
+
+
 ## v23.29
 
 - v23.29-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - v24.19-alpha
 
+### Compatibility
+
+No breaking changes, tested with Seacat Auth v24.17-beta2
+
 ### Features
 
 - Advanced password validation (#43, v24.19-alpha, PLUM Sprint 240503)

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -199,7 +199,7 @@
 		"Passwords do not match": "Hesla se neshodují!",
 		"Short password": "Heslo je příliš krátké!",
 		"Something went wrong, unable to set the password": "Něco je špatně, nepodařilo se nastavit heslo",
-		"Your password reset link has likely expired. You can request a new one.": "Váš odkaz k obnovení hesla pravděpodobně vypršel. Můžete si nechat zaslat odkaz nový.",
+		"Your password reset link has likely expired. Please request a new one.": "Váš odkaz k obnovení hesla pravděpodobně vypršel. Můžete si nechat zaslat odkaz nový.",
 		"CompletedResetPwdCard": {
 			"Password set": "Heslo bylo nastaveno",
 			"Continue": "Pokračovat"

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -145,8 +145,9 @@
 		"Fill in your login credentials": "Vložte prosím Vaše přihlašovací údaje"
 	},
 	"ChangePwdScreen": {
-		"Set password": "Nastavení hesla",
-		"Set new password here": "Zde si můžete nastavit Vaše nové heslo",
+		"Password change": "Změna hesla",
+		"Set password": "Změnit heslo",
+		"Set new password here": "Zde si můžete nastavit nové heslo",
 		"Current Password": "Stávající heslo",
 		"New Password": "Nové heslo",
 		"Re-enter Password": "Nové heslo znovu",

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -190,7 +190,8 @@
 	},
 	"ResetPwdScreen": {
 		"Set password": "Nastavení hesla",
-		"Set new password here": "Zde si můžete nastavit Vaše nové heslo",
+		"Set new password": "Nastavit nové heslo",
+		"Set a new password here": "Zde si můžete nastavit Vaše nové heslo",
 		"Current Password": "Stávající heslo",
 		"New Password": "Nové heslo",
 		"Re-enter Password": "Nové heslo znovu",
@@ -198,7 +199,7 @@
 		"Passwords do not match": "Hesla se neshodují!",
 		"Short password": "Heslo je příliš krátké!",
 		"Something went wrong, unable to set the password": "Něco je špatně, nepodařilo se nastavit heslo",
-		"Invalid password reset link, please set your password again": "Neplatný odkaz k obnovení hesla, prosím nastavte Vaše heslo znovu",
+		"Your password reset link has likely expired. You can request a new one.": "Váš odkaz k obnovení hesla pravděpodobně vypršel. Můžete si nechat zaslat odkaz nový.",
 		"CompletedResetPwdCard": {
 			"Password set": "Heslo bylo nastaveno",
 			"Continue": "Pokračovat"

--- a/public/locales/cs/translation.json
+++ b/public/locales/cs/translation.json
@@ -159,7 +159,14 @@
 			"Password changed": "Heslo bylo změněno",
 			"Go back": "Zpět"
 		},
-		"Something went wrong": "Something went wrong"
+		"Something went wrong": "Something went wrong",
+		"New password must be different from your old password": "Nové heslo nesmí být stejné jako vaše stávající heslo",
+		"The password must meet the following criteria:": "Heslo musí splňovat tato kritéria:",
+		"It must consist of {{minLength}} or more characters": "Musí být alespoň {{minLength}} znaků dlouhé",
+		"It must contain at least {{minLowercaseCount}} lowercase characters": "Musí obsahovat alespoň {{minLowercaseCount}} malých písmen",
+		"It must contain at least {{minUppercaseCount}} uppercase characters": "Musí obsahovat alespoň {{minUppercaseCount}} velkých písmen",
+		"It must contain at least {{minDigitCount}} digits": "Musí obsahovat alespoň {{minDigitCount}} číslic",
+		"It must contain at least {{minSpecialCount}} special characters": "Musí obsahovat alespoň {{minSpecialCount}} speciálních znaků"
 	},
 	"PhoneNumberScreen": {
 		"Do you want to change your number?": "Opravdu chcete změnit vaše telefonní číslo?",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -190,7 +190,8 @@
 	},
 	"ResetPwdScreen": {
 		"Set password": "Set password",
-		"Set new password here": "You can set your new password here",
+		"Set new password": "Set new password",
+		"Set a new password here": "You can set your new password here",
 		"Current Password": "Current password",
 		"New Password": "New password",
 		"Re-enter Password": "Re-enter the new password",
@@ -198,7 +199,7 @@
 		"Passwords do not match": "Passwords do not match!",
 		"Short password": "Password is too short!",
 		"Something went wrong, unable to set the password": "Something went wrong, unable to set the password",
-		"Invalid password reset link, please set your password again": "Invalid password reset link, please set your password again",
+		"Your password reset link has likely expired. You can request a new one.": "Your password reset link has likely expired. You can request a new one.",
 		"CompletedResetPwdCard": {
 			"Password set": "Password has been set",
 			"Continue": "Continue"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -159,7 +159,14 @@
 			"Password changed": "Password has been changed",
 			"Go back": "Go back"
 		},
-		"Something went wrong": "Something went wrong"
+		"Something went wrong": "Something went wrong",
+		"New password must be different from your old password": "New password must be different from your old password",
+		"The password must meet the following criteria:": "The password must meet the following criteria:",
+		"It must consist of {{minLength}} or more characters": "It must consist of {{minLength}} or more characters",
+		"It must contain at least {{minLowercaseCount}} lowercase characters": "It must contain at least {{minLowercaseCount}} lowercase characters",
+		"It must contain at least {{minUppercaseCount}} uppercase characters": "It must contain at least {{minUppercaseCount}} uppercase characters",
+		"It must contain at least {{minDigitCount}} digits": "It must contain at least {{minDigitCount}} digits",
+		"It must contain at least {{minSpecialCount}} special characters": "It must contain at least {{minSpecialCount}} special characters"
 	},
 	"PhoneNumberScreen": {
 		"Do you want to change your number?": "Do you want to change your number?",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -145,6 +145,7 @@
 		"Fill in your login credentials": "Please fill in your login credentials"
 	},
 	"ChangePwdScreen": {
+		"Password change": "Password change",
 		"Set password": "Set password",
 		"Set new password here": "You can set your new password here",
 		"Current Password": "Current password",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -199,7 +199,7 @@
 		"Passwords do not match": "Passwords do not match!",
 		"Short password": "Password is too short!",
 		"Something went wrong, unable to set the password": "Something went wrong, unable to set the password",
-		"Your password reset link has likely expired. You can request a new one.": "Your password reset link has likely expired. You can request a new one.",
+		"Your password reset link has likely expired. Please request a new one.": "Your password reset link has likely expired. Please request a new one.",
 		"CompletedResetPwdCard": {
 			"Password set": "Password has been set",
 			"Continue": "Continue"

--- a/src/modules/auth/passwd/ChangePwdScreen.js
+++ b/src/modules/auth/passwd/ChangePwdScreen.js
@@ -111,9 +111,9 @@ function ChangePwdCard(props) {
 			}
 		} catch (e) {
 			if (e?.response?.status == 401 || e?.response?.data?.result == 'UNAUTHORIZED') {
-				props.app.addAlertFromException(e, t('ChangePwdScreen|The current password is incorrect'));
+				props.app.addAlert("danger", t('ChangePwdScreen|The current password is incorrect'), 30);
 			} else {
-				props.app.addAlertFromException(e, t('ChangePwdScreen|Password change failed'));
+				props.app.addAlert("danger", `${t("ResetPwdScreen|Password change failed")}. ${e?.response?.data?.message}`, 30);
 			}
 
 			return;

--- a/src/modules/auth/passwd/ChangePwdScreen.js
+++ b/src/modules/auth/passwd/ChangePwdScreen.js
@@ -104,7 +104,7 @@ function ChangePwdCard(props) {
 
 	const onSubmit = async (values) => {
 		try {
-			const response = await SeaCatAuthAPI.put('/account/password-change', values);
+			const response = await SeaCatAuthAPI.put('/public/password-change', values);
 
 			if (response.data.result !== 'OK') {
 				throw new Error(t('ChangePwdScreen|Unexpected server response'));

--- a/src/modules/auth/passwd/ChangePwdScreen.js
+++ b/src/modules/auth/passwd/ChangePwdScreen.js
@@ -106,7 +106,7 @@ function ChangePwdCard(props) {
 		try {
 			const response = await SeaCatAuthAPI.put('/account/password-change', values);
 
-			if (response.data.result != 'OK') {
+			if (response.data.result !== 'OK') {
 				throw new Error(t('ChangePwdScreen|Unexpected server response'));
 			}
 		} catch (e) {
@@ -228,7 +228,7 @@ function ChangePwdCard(props) {
 						{errors.newpassword2 ?
 							<FormFeedback>{errors.newpassword2.message}</FormFeedback>
 							:
-							<FormText>
+							<FormText className='text-left'>
 								{t('ChangePwdScreen|Enter new password a second time to verify it')}
 							</FormText>
 						}

--- a/src/modules/auth/passwd/ResetPwdScreen.js
+++ b/src/modules/auth/passwd/ResetPwdScreen.js
@@ -9,6 +9,14 @@ import {
 	Form, FormGroup, FormText, Label, Input, Button, FormFeedback
 } from 'reactstrap';
 import generatePenrose from '../utils/generatePenrose';
+import {
+	validatePasswordLength,
+	validatePasswordLowercaseCount,
+	validatePasswordUppercaseCount,
+	validatePasswordDigitCount,
+	validatePasswordSpecialCount,
+	PasswordCriteriaFeedback,
+} from '../utils/passwordValidation';
 
 function ResetPwdScreen(props) {
 
@@ -28,13 +36,51 @@ export default ResetPwdScreen;
 
 function ResetPwdCard(props) {
 	const { t, i18n } = useTranslation();
-	const { handleSubmit, register, getValues, formState: { errors, isSubmitting } } = useForm();
+	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
+	const { handleSubmit, register, getValues, watch, formState: { errors, isSubmitting } } = useForm();
 
 	generatePenrose();
 	
 	let history = useHistory();
 
 	const [ completed, setCompleted ] = useState(false);
+	const [ passwordCriteria, setPasswordCriteria ] = useState({
+		minLength: 10,
+	});
+
+	useEffect(() => {
+		loadPasswordCriteria();
+	}, []);
+
+	const loadPasswordCriteria = async () => {
+		try {
+			const response = await SeaCatAuthAPI.get('/public/password/policy');
+			setPasswordCriteria({
+				minLength: response.data?.min_length,
+				minLowercaseCount: response.data?.min_lowercase_count,
+				minUppercaseCount: response.data?.min_uppercase_count,
+				minDigitCount: response.data?.min_digit_count,
+				minSpecialCount: response.data?.min_special_count,
+			});
+		} catch (e) {
+			if (e?.response?.status == 404) {
+				// Most likely older service version which does not have this endpoint
+				console.error(e);
+			} else {
+				props.app.addAlertFromException(e, t('ChangePwdScreen|Failed to load password criteria'));
+			}
+		}
+	};
+
+	// Password is watched for immediate feedback to the user
+	const watchedNewPassword = watch('newpassword', '');
+	const validateNewPassword = (value) => ({
+		minLength: validatePasswordLength(value, passwordCriteria?.minLength),
+		minLowercaseCount: validatePasswordLowercaseCount(value, passwordCriteria?.minLowercaseCount),
+		minUppercaseCount: validatePasswordUppercaseCount(value, passwordCriteria?.minUppercaseCount),
+		minDigitCount: validatePasswordDigitCount(value, passwordCriteria?.minDigitCount),
+		minSpecialCount: validatePasswordSpecialCount(value, passwordCriteria?.minSpecialCount),
+	});
 
 	const isButtonRemoved = props.app.Config.get('password_change')?.remove_btn;
 
@@ -45,7 +91,8 @@ function ResetPwdCard(props) {
 
 	const regNewpwd = register("newpassword",{
 		validate: {
-			shortInput: value => (getValues().newpassword.length >= 4) || t("ResetPwdScreen|Short password"),
+			passwordCriteria: (value) => (Object.values(validateNewPassword(value)).every(Boolean)
+			|| t('ChangePwdScreen|Password does not meet security requirements')),
 		}
 	});
 	const regNewpwd2 = register("newpassword2",{
@@ -56,7 +103,6 @@ function ResetPwdCard(props) {
 
 
 	const onSubmit = async (values) => {
-		let SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
 		let response;
 		values.pwd_token = resetPasswordCode;
 
@@ -160,50 +206,51 @@ function ResetPwdCard(props) {
 					</div>
 				</CardHeader>
 				<CardBody className="pb-1">
-					<FormGroup tag="fieldset" disabled={isSubmitting} style={{textAlign: "center"}}>
-						<h5>
-							<Label for="newpassword" style={{display: "block"}}>
-								{t('ResetPwdScreen|New Password')}
-							</Label>
-						</h5>
+					<FormGroup tag='fieldset' disabled={isSubmitting}>
+						<Label for='newpassword'>
+							{t('ChangePwdScreen|New password')}
+						</Label>
 						<Input
-							autoFocus
-							id="newpassword"
-							name="newpassword"
-							type="password"
-							invalid={errors.newpassword}
-							autoComplete="new-password"
-							required="required"
+							id='newpassword'
+							name='newpassword'
+							type='password'
+							autoComplete='new-password'
+							required='required'
+							invalid={Boolean(errors?.newpassword)}
 							onBlur={regNewpwd.onBlur}
 							innerRef={regNewpwd.ref}
 							onChange={regNewpwd.onChange}
 						/>
-						{errors.newpassword && <FormFeedback>{errors.newpassword.message}</FormFeedback>}
+						{errors?.newpassword?.type !== 'passwordCriteria'
+							&& <FormFeedback>{errors?.newpassword?.message}</FormFeedback>
+						}
+						<PasswordCriteriaFeedback
+							passwordCriteria={passwordCriteria}
+							validatePassword={validateNewPassword}
+							watchedPassword={watchedNewPassword}
+							passwordErrors={errors?.newpassword}
+						/>
 					</FormGroup>
 
-					<FormGroup tag="fieldset" disabled={isSubmitting} style={{textAlign: "center"}}>
-						<h5>
-							<Label for="newpassword2" style={{display: "block"}}>
-								{t('ResetPwdScreen|Re-enter Password')}
-							</Label>
-						</h5>
+					<FormGroup tag='fieldset' disabled={isSubmitting}>
+						<Label for='newpassword2'>
+							{t('ChangePwdScreen|Re-enter password')}
+						</Label>
 						<Input
-							id="newpassword2"
-							name="newpassword2"
-							type="password"
-							autoComplete="new-password"
-							required="required"
-							invalid={errors.newpassword2}
+							id='newpassword2'
+							name='newpassword2'
+							type='password'
+							autoComplete='new-password'
+							required='required'
+							invalid={Boolean(errors?.newpassword2)}
 							onChange={regNewpwd2.onChange}
 							onBlur={regNewpwd2.onBlur}
 							innerRef={regNewpwd2.ref}
 						/>
-
-						{errors.newpassword2 ?
-							<FormFeedback>{errors.newpassword2.message}</FormFeedback>
-							:
-							<FormText>
-								{t('ResetPwdScreen|Enter new password a second time to verify it')}
+						{errors?.newpassword2
+							? <FormFeedback>{errors?.newpassword2.message}</FormFeedback>
+							: <FormText>
+								{t('ChangePwdScreen|Enter your new password again for verification')}
 							</FormText>
 						}
 					</FormGroup>

--- a/src/modules/auth/passwd/ResetPwdScreen.js
+++ b/src/modules/auth/passwd/ResetPwdScreen.js
@@ -113,10 +113,10 @@ function ResetPwdCard(props) {
 			}
 		} catch (e) {
 			if (e?.response?.status == 401 || e?.response?.data?.result == 'UNAUTHORIZED') {
-				props.app.addAlertFromException(e, t('ResetPwdScreen|Your password reset link has likely expired. Please request a new one.'));
+				props.app.addAlert("danger", t('ResetPwdScreen|Your password reset link has likely expired. Please request a new one.', 30));
 				onRedirect("/cant-login", true);
 			} else {
-				props.app.addAlertFromException(e, t('ResetPwdScreen|Password change failed'));
+				props.app.addAlert("danger", `${t("ResetPwdScreen|Password change failed")}. ${e?.response?.data?.message}`, 30);
 			}
 
 			return;
@@ -209,7 +209,7 @@ function ResetPwdCard(props) {
 				<CardBody className="pb-1">
 					<FormGroup tag='fieldset' disabled={isSubmitting}>
 						<Label for='newpassword'>
-							{t('ChangePwdScreen|New password')}
+							{t('ResetPwdScreen|New Password')}
 						</Label>
 						<Input
 							id='newpassword'
@@ -235,7 +235,7 @@ function ResetPwdCard(props) {
 
 					<FormGroup tag='fieldset' disabled={isSubmitting}>
 						<Label for='newpassword2'>
-							{t('ChangePwdScreen|Re-enter password')}
+							{t('ResetPwdScreen|Re-enter Password')}
 						</Label>
 						<Input
 							id='newpassword2'
@@ -251,7 +251,7 @@ function ResetPwdCard(props) {
 						{errors?.newpassword2
 							? <FormFeedback>{errors?.newpassword2.message}</FormFeedback>
 							: <FormText>
-								{t('ChangePwdScreen|Enter your new password again for verification')}
+								{t('ResetPwdScreen|Enter new password a second time to verify it')}
 							</FormText>
 						}
 					</FormGroup>

--- a/src/modules/auth/passwd/ResetPwdScreen.js
+++ b/src/modules/auth/passwd/ResetPwdScreen.js
@@ -108,16 +108,17 @@ function ResetPwdCard(props) {
 
 		try {
 			response = await SeaCatAuthAPI.put("/public/password-reset", values);
-			if (response.data.result === 'INVALID-CODE') {
-				props.app.addAlert("danger", t("ResetPwdScreen|Invalid password reset link, please set your password again"), 30);
-				onRedirect("/cant-login", true);
-				return;
-			}
 			if (response.data.result !== 'OK') {
 				throw new Error(t("ResetPwdScreen|Something went wrong, unable to set the password"));
 			}
 		} catch (e) {
-			props.app.addAlert("danger", `${t("ResetPwdScreen|Something went wrong, unable to set the password")}. ${e?.response?.data?.message}`, 30);
+			if (e?.response?.status == 401 || e?.response?.data?.result == 'UNAUTHORIZED') {
+				props.app.addAlertFromException(e, t('ResetPwdScreen|Your password reset link has likely expired. Please request a new one.'));
+				onRedirect("/cant-login", true);
+			} else {
+				props.app.addAlertFromException(e, t('ResetPwdScreen|Password change failed'));
+			}
+
 			return;
 		}
 		setCompleted(true);
@@ -201,7 +202,7 @@ function ResetPwdCard(props) {
 					<div className="card-header-title" >
 						<CardTitle className="text-primary" tag="h2">{t('ResetPwdScreen|Set password')}</CardTitle>
 						<CardSubtitle tag="p">
-							{t('ResetPwdScreen|Set new password here')}
+							{t('ResetPwdScreen|Set a new password here')}
 						</CardSubtitle>
 					</div>
 				</CardHeader>
@@ -263,7 +264,7 @@ function ResetPwdCard(props) {
 							type="submit"
 							disabled={isSubmitting}
 						>
-							{t("ResetPwdScreen|Set password")}
+							{t("ResetPwdScreen|Set new password")}
 						</Button>
 					</FormGroup>
 				</CardBody>

--- a/src/modules/auth/passwd/ResetPwdScreen.js
+++ b/src/modules/auth/passwd/ResetPwdScreen.js
@@ -40,8 +40,8 @@ function ResetPwdCard(props) {
 	const { handleSubmit, register, getValues, watch, formState: { errors, isSubmitting } } = useForm();
 
 	generatePenrose();
-	
-	let history = useHistory();
+
+	const history = useHistory();
 
 	const [ completed, setCompleted ] = useState(false);
 	const [ passwordCriteria, setPasswordCriteria ] = useState({

--- a/src/modules/auth/passwd/ResetPwdScreen.js
+++ b/src/modules/auth/passwd/ResetPwdScreen.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
-import { Link, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 
 import {
 	Container, Row, Col,
-	Card, CardHeader, CardTitle, CardSubtitle, CardBody, CardFooter,
+	Card, CardHeader, CardTitle, CardSubtitle, CardBody,
 	Form, FormGroup, FormText, Label, Input, Button, FormFeedback
 } from 'reactstrap';
 import generatePenrose from '../utils/generatePenrose';
@@ -35,7 +35,7 @@ function ResetPwdScreen(props) {
 export default ResetPwdScreen;
 
 function ResetPwdCard(props) {
-	const { t, i18n } = useTranslation();
+	const { t } = useTranslation();
 	const SeaCatAuthAPI = props.app.axiosCreate('seacat-auth');
 	const { handleSubmit, register, getValues, watch, formState: { errors, isSubmitting } } = useForm();
 
@@ -89,13 +89,13 @@ function ResetPwdCard(props) {
 	let params = new URLSearchParams(qs);
 	let resetPasswordCode = params.get("pwd_token");
 
-	const regNewpwd = register("newpassword",{
+	const regNewpwd = register("newpassword", {
 		validate: {
 			passwordCriteria: (value) => (Object.values(validateNewPassword(value)).every(Boolean)
 			|| t('ChangePwdScreen|Password does not meet security requirements')),
 		}
 	});
-	const regNewpwd2 = register("newpassword2",{
+	const regNewpwd2 = register("newpassword2", {
 		validate: {
 			passEqual: value => (value === getValues().newpassword) || t("ResetPwdScreen|Passwords do not match"),
 		}

--- a/src/modules/auth/utils/passwordValidation.js
+++ b/src/modules/auth/utils/passwordValidation.js
@@ -38,7 +38,7 @@ export function PasswordCriteriaFeedback({ passwordCriteria, validatePassword, w
 	const invalidColor = (passwordErrors?.type == 'passwordCriteria') ? 'text-danger' : '';
 
 	return (
-		<FormText>
+		<FormText className='text-left'>
 			{/*
 				Every password requirement has the default (muted) color until fulfilled or form is submitted.
 				Once fulfilled, it **immediately** turns green.
@@ -51,35 +51,35 @@ export function PasswordCriteriaFeedback({ passwordCriteria, validatePassword, w
 			{Boolean(passwordCriteria.minLength)
 				&& <div className={validatedNewPassword.minLength ? 'text-success' : invalidColor
 				}>
-					<i className={validatedNewPassword.minLength ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					<i className={validatedNewPassword.minLength ? 'cil-check-alt px-1' : 'cil-x px-1'} />
 					{t('ChangePwdScreen|It must consist of {{minLength}} or more characters', passwordCriteria)}
 				</div>
 			}
 			{Boolean(passwordCriteria.minLowercaseCount)
 				&& <div className={validatedNewPassword.minLowercaseCount ? 'text-success' : invalidColor
 				}>
-					<i className={validatedNewPassword.minLowercaseCount ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					<i className={validatedNewPassword.minLowercaseCount ? 'cil-check-alt px-1' : 'cil-x px-1'} />
 					{t('ChangePwdScreen|It must contain at least {{minLowercaseCount}} lowercase characters', passwordCriteria)}
 				</div>
 			}
 			{Boolean(passwordCriteria.minUppercaseCount)
 				&& <div className={validatedNewPassword.minUppercaseCount ? 'text-success' : invalidColor
 				}>
-					<i className={validatedNewPassword.minUppercaseCount ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					<i className={validatedNewPassword.minUppercaseCount ? 'cil-check-alt px-1' : 'cil-x px-1'} />
 					{t('ChangePwdScreen|It must contain at least {{minUppercaseCount}} uppercase characters', passwordCriteria)}
 				</div>
 			}
 			{Boolean(passwordCriteria.minDigitCount)
 				&& <div className={validatedNewPassword.minDigitCount ? 'text-success' : invalidColor
 				}>
-					<i className={validatedNewPassword.minDigitCount ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					<i className={validatedNewPassword.minDigitCount ? 'cil-check-alt px-1' : 'cil-x px-1'} />
 					{t('ChangePwdScreen|It must contain at least {{minDigitCount}} digits', passwordCriteria)}
 				</div>
 			}
 			{Boolean(passwordCriteria.minSpecialCount)
 				&& <div className={validatedNewPassword.minSpecialCount ? 'text-success' : invalidColor
 				}>
-					<i className={validatedNewPassword.minSpecialCount ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					<i className={validatedNewPassword.minSpecialCount ? 'cil-check-alt px-1' : 'cil-x px-1'} />
 					{t('ChangePwdScreen|It must contain at least {{minSpecialCount}} special characters', passwordCriteria)}
 				</div>
 			}

--- a/src/modules/auth/utils/passwordValidation.js
+++ b/src/modules/auth/utils/passwordValidation.js
@@ -35,7 +35,7 @@ export function validatePasswordSpecialCount(password, minSpecialCount) {
 export function PasswordCriteriaFeedback({ passwordCriteria, validatePassword, watchedPassword, passwordErrors }) {
 	const { t } = useTranslation();
 	const validatedNewPassword = validatePassword(watchedPassword);
-	const invalidColor = (passwordErrors?.type == 'passwordCriteria') ? 'text-danger' : '';
+	const invalidColor = (passwordErrors?.type == 'passwordCriteria') ? 'text-danger' : 'text-muted';
 
 	return (
 		<FormText className='text-left'>

--- a/src/modules/auth/utils/passwordValidation.js
+++ b/src/modules/auth/utils/passwordValidation.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { FormText } from 'reactstrap';
+
+export function validatePasswordLength(password, minLength) {
+	// Check if the password is long enough
+	return (!minLength)
+		|| (password.length >= minLength);
+}
+
+export function validatePasswordLowercaseCount(password, minLowercaseCount) {
+	// Check if the password contains enough lowercase characters
+	return (!minLowercaseCount)
+		|| ((password.match(/[a-z]/g) || []).length >= minLowercaseCount);
+}
+
+export function validatePasswordUppercaseCount(password, minUppercaseCount) {
+	// Check if the password contains enough uppercase characters
+	return (!minUppercaseCount)
+		|| ((password.match(/[A-Z]/g) || []).length >= minUppercaseCount);
+}
+
+export function validatePasswordDigitCount(password, minDigitCount) {
+	// Check if the password contains enough digits
+	return (!minDigitCount)
+		|| ((password.match(/[0-9]/g) || []).length >= minDigitCount);
+}
+
+export function validatePasswordSpecialCount(password, minSpecialCount) {
+	// Check if the password contains enough special characters
+	return (!minSpecialCount)
+		|| ((password.match(/[^a-zA-Z0-9]/g) || []).length >= minSpecialCount);
+}
+
+export function PasswordCriteriaFeedback({ passwordCriteria, validatePassword, watchedPassword, passwordErrors }) {
+	const { t } = useTranslation();
+	const validatedNewPassword = validatePassword(watchedPassword);
+	const invalidColor = (passwordErrors?.type == 'passwordCriteria') ? 'text-danger' : '';
+
+	return (
+		<FormText>
+			{/*
+				Every password requirement has the default (muted) color until fulfilled or form is submitted.
+				Once fulfilled, it **immediately** turns green.
+				Once the form is submitted, all the unmet requirements turn red.
+			*/}
+			<div className={Object.values(validatedNewPassword).every(Boolean) ? 'text-success' : invalidColor
+			}>
+				{t('ChangePwdScreen|The password must meet the following criteria:')}
+			</div>
+			{Boolean(passwordCriteria.minLength)
+				&& <div className={validatedNewPassword.minLength ? 'text-success' : invalidColor
+				}>
+					<i className={validatedNewPassword.minLength ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					{t('ChangePwdScreen|It must consist of {{minLength}} or more characters', passwordCriteria)}
+				</div>
+			}
+			{Boolean(passwordCriteria.minLowercaseCount)
+				&& <div className={validatedNewPassword.minLowercaseCount ? 'text-success' : invalidColor
+				}>
+					<i className={validatedNewPassword.minLowercaseCount ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					{t('ChangePwdScreen|It must contain at least {{minLowercaseCount}} lowercase characters', passwordCriteria)}
+				</div>
+			}
+			{Boolean(passwordCriteria.minUppercaseCount)
+				&& <div className={validatedNewPassword.minUppercaseCount ? 'text-success' : invalidColor
+				}>
+					<i className={validatedNewPassword.minUppercaseCount ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					{t('ChangePwdScreen|It must contain at least {{minUppercaseCount}} uppercase characters', passwordCriteria)}
+				</div>
+			}
+			{Boolean(passwordCriteria.minDigitCount)
+				&& <div className={validatedNewPassword.minDigitCount ? 'text-success' : invalidColor
+				}>
+					<i className={validatedNewPassword.minDigitCount ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					{t('ChangePwdScreen|It must contain at least {{minDigitCount}} digits', passwordCriteria)}
+				</div>
+			}
+			{Boolean(passwordCriteria.minSpecialCount)
+				&& <div className={validatedNewPassword.minSpecialCount ? 'text-success' : invalidColor
+				}>
+					<i className={validatedNewPassword.minSpecialCount ? 'cis-check-alt pe-1' : 'cis-x pe-1'} />
+					{t('ChangePwdScreen|It must contain at least {{minSpecialCount}} special characters', passwordCriteria)}
+				</div>
+			}
+		</FormText>
+	);
+}


### PR DESCRIPTION
porting changes from this MR
http://gitlab.teskalabs.int/ateska/webui-microfrontends-poc/-/merge_requests/291

# Summary

- The change password form validates the new password with minimum password requirements obtained from `GET /public/password/policy`.
- There is a backward-compatibility fallback for older service versions which do not have the mentioned endpoint.
- The form gives immediate feedback to the user about whether their new password meets all the requirements.
- There is also a check that the new password is not the same as the old one.
- Updated the "Lost password reset" and "Password change" screens.
- Translations updated.

# Compatibility

- The password policy endpoint will be made available in Seacat Auth by this MR https://github.com/TeskaLabs/seacat-auth/pull/372
- Current and earlier Seacat Auth versions do not have this endpoint, so the web app will use a fallback validation.

# Preview

Lost password reset

![Screenshot from 2024-05-10 13-44-07](https://github.com/TeskaLabs/seacat-auth-webui/assets/11579460/67e5b17a-b614-4867-9008-62c9e7a73ea4)

Password change

![Screenshot from 2024-05-10 13-09-03](https://github.com/TeskaLabs/seacat-auth-webui/assets/11579460/1e707cc2-dcfb-4d7c-a3b8-b748d9ebfc68)

