### PR TITLE
Rename password field in registration form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ No breaking changes, tested with Seacat Auth v24.17-beta2
 
 ### Fix
 
-- Rename password field in registration form (#45, v24.19-alpha2, PLUM Sprint 240531)
+- Rename password field in registration form (#45, v24.19-alpha3, PLUM Sprint 240531)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### Releases
 
-- v24.19-alpha2
+- v24.19-alpha3
+- ~~v24.19-alpha2~~
 - v24.19-alpha
 
 ### Compatibility
 
 No breaking changes, tested with Seacat Auth v24.17-beta2
+
+### Fix
+
+- Rename password field in registration form (#45, v24.19-alpha2, PLUM Sprint 240531)
 
 ### Features
 

--- a/src/modules/auth/containers/RegistrationCard.js
+++ b/src/modules/auth/containers/RegistrationCard.js
@@ -28,8 +28,10 @@ function RegistrationCard(props) {
 		filled input data (on press Save)
 	*/
 	const onSubmit = async (values) => {
-		let body = values;
-		delete body["password2"];
+		const body = values;
+		body.password = values.newpassword;
+		delete body.newpassword;
+		delete body.newpassword2;
 		Promise.all(Object.keys(body).map((key, i) => {
 			if ((body[key] == undefined) || (body[key].length == 0)) {
 				delete body[key];


### PR DESCRIPTION
post-fix to #44, which broke the naming of registration fields

# Summary
- Password fields `newpassword` and `newpassword2` from `PasswordChangeFieldGroup` are replaced with `password` in registration form to comply with backend API.